### PR TITLE
Fixed Unsatisfied dependency tree errors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,8 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-CUDA = "4.2.0"
+CUDA = "5.4.2"
 Parameters = "0.12.3"
 Revise= "3.3.1"
 StaticArrays = "1.5.0"
-julia = ">1.8.5"
+julia = "1.9"


### PR DESCRIPTION
Fixed errors for julia 1.10, which resulting in breaking other packages that required medeval 0.2.0 as a dependency.
Dr. @jakubMitura14, i hope the repo is synced with the registry.