### PR TITLE
Fixed Precompilation output

### DIFF
--- a/src/kernels/TpfpfnKernel.jl
+++ b/src/kernels/TpfpfnKernel.jl
@@ -64,7 +64,7 @@ conf- adapted ConfigurtationStruct - used to pass information what metrics shoul
 """
 function getTpfpfnData!(goldGPU
     , segmGPU
-    ,args,threads,blocks,metricsTuplGlobal,numberToLooFor,conf) where T
+    ,args,threads,blocks,metricsTuplGlobal,numberToLooFor,conf)
 
 for i in  1:4   
     CUDA.fill!(args[i],0)


### PR DESCRIPTION
--Precompilation output for the unused atomic variable producing warning during pre-compilation of the package removed.