### PR TITLE
Updates to InterClassCorrKernel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 CUDA = "5.4.2"
 Parameters = "0.12.3"
-Revise= "3.3.1"
+Revise = "3.3.1"
 StaticArrays = "1.5.0"
 julia = "1.9"

--- a/src/kernels/InterClassCorrKernel.jl
+++ b/src/kernels/InterClassCorrKernel.jl
@@ -3,8 +3,6 @@
 new optimazation idea  - try to put all data in boolean arrays in shared memory  when getting means
 next we would need only to read shared memory - yet first one need to check wheather there would be enough shmem on device
 
-
-
 calculating intercalss correlation
 """
 module InterClassCorrKernel
@@ -16,6 +14,8 @@ using Statistics
 using Atomix
 
 export prepareInterClassCorrKernel, calculateInterclassCorr
+
+backend = CUDABackend()
 
 @kernel function kernel_interclass_corr!(
     flat_gold, 
@@ -82,11 +82,11 @@ function prepareInterClassCorrKernel(flat_gold, flat_segm, number_to_look_for)
     total_elements = length(flat_gold)
 
     # GPU memory allocations
-    sum_of_gold = CUDA.zeros(Float32, 1)
-    sum_of_segm = CUDA.zeros(Float32, 1)
-    ssw_total = CUDA.zeros(Float32, 1)
-    ssb_total = CUDA.zeros(Float32, 1)
-    grand_mean = CUDA.zeros(Float32, 1)
+    sum_of_gold = KernelAbstractions.zeros(backend, Float32, 1)
+    sum_of_segm = KernelAbstractions.zeros(backend, Float32, 1)
+    ssw_total = KernelAbstractions.zeros(backend, Float32, 1)
+    ssb_total = KernelAbstractions.zeros(backend, Float32, 1)
+    grand_mean = KernelAbstractions.zeros(backend, Float32, 1)
 
     # Configure thread blocks - respect hardware limits
     threads_per_block = 256  # Using 256 threads per block for better occupancy

--- a/test/ICtest.jl
+++ b/test/ICtest.jl
@@ -5,14 +5,24 @@ using ..CUDAGpuUtils ,..IterationUtils,..ReductionUtils , ..MemoryUtils,..CUDAAt
 using Shuffle,..ResultListUtils, ..MetadataAnalyzePass,..MetaDataUtils,..WorkQueueUtils,..ProcessMainDataVerB,..HFUtils, ..ScanForDuplicates
 using ..MainOverlap, ..RandIndex , ..ProbabilisticMetrics , ..VolumeMetric ,..InformationTheorhetic
 using ..CUDAAtomicUtils, ..TpfpfnKernel, ..InterClassCorrKernel
+
 dimx = 529
 dimy = 556
 dimz = 339
 arrGold = CUDA.fill(UInt8(1), (dimx, dimy, dimz))
 arrAlgo = CUDA.fill(UInt8(1), (dimx, dimy, dimz))
 numberToLooFor = UInt8(1)
-args, workgroup_size, num_workgroups, total_num_voxels=InterClassCorrKernel.prepareInterClassCorrKernel(arrGold ,arrAlgo,numberToLooFor)
-globalICC = InterClassCorrKernel.calculateInterclassCorr(arrGold, arrAlgo, numberToLooFor)
 
-Int64(args[1][1] - dimx * dimy * dimz)
-args[1][2] == dimx * dimy * dimz
+# Calculate ICC first to ensure kernel execution
+globalICC = InterClassCorrKernel.calculateInterclassCorr(arrGold, arrAlgo, numberToLooFor)
+CUDA.synchronize()
+
+# Now safely retrieve the sums using proper scalar access
+sum_of_gold, sum_of_segm, _, _, _ = InterClassCorrKernel.prepareInterClassCorrKernel(arrGold, arrAlgo, numberToLooFor)
+
+gold_sum = CUDA.@allowscalar sum_of_gold[]
+segm_sum = CUDA.@allowscalar sum_of_segm[]
+
+println("Gold sum: ", gold_sum)
+println("Segm sum: ", segm_sum)
+println("Global ICC: ", globalICC)

--- a/test/ICtest.jl
+++ b/test/ICtest.jl
@@ -8,11 +8,11 @@ using ..CUDAAtomicUtils, ..TpfpfnKernel, ..InterClassCorrKernel
 dimx = 529
 dimy = 556
 dimz = 339
-arrGold = CUDA.ones(UInt8, (dimx,dimy,dimz) )
-arrAlgo = CUDA.ones(UInt8, (dimx,dimy,dimz) )
+arrGold = CUDA.fill(UInt8(1), (dimx, dimy, dimz))
+arrAlgo = CUDA.fill(UInt8(1), (dimx, dimy, dimz))
 numberToLooFor = UInt8(1)
-argsMain, threadsMain,  blocksMain,threadsMean,blocksMean,argsMean, totalNumbOfVoxels=InterClassCorrKernel.prepareInterClassCorrKernel(arrGold ,arrAlgo,numberToLooFor)
-globalICC=calculateInterclassCorr(arrGold,arrAlgo,argsMain, threadsMain,  blocksMain,threadsMean,blocksMean,argsMean, totalNumbOfVoxels)::Float64
+args, workgroup_size, num_workgroups, total_num_voxels=InterClassCorrKernel.prepareInterClassCorrKernel(arrGold ,arrAlgo,numberToLooFor)
+globalICC = InterClassCorrKernel.calculateInterclassCorr(arrGold, arrAlgo, numberToLooFor)
 
-Int64(argsMain[1][1]-dimx*dimy*dimz)
-argsMain[2][1]==dimx*dimy*dimz
+Int64(args[1][1] - dimx * dimy * dimz)
+args[1][2] == dimx * dimy * dimz


### PR DESCRIPTION
Error: 

```julia
ERROR: LoadError: Number of threads in x-dimension exceeds device limit (99708160 > 1024).
Stacktrace:
  [1] error(s::String)
    @ Base .\error.jl:35
  [2] diagnose_launch_failure(f::CuFunction, err::CuError; blockdim::CuDim3, threaddim::CuDim3, shmem::Int64)
    @ CUDA C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:97
  [3] launch(::CuFunction, ::CUDA.KernelState, ::CuDeviceArray{UInt8, 3, 1}, ::CuDeviceArray{UInt8, 3, 1}, ::CuDeviceVector{Float32, 1}, ::CuDeviceVector{Float32, 1}, ::CuDeviceVector{Float32, 1}, ::CuDeviceVector{Float32, 1}, ::UInt8, ::CuDeviceVector{Float32, 1}; blocks::Int64, threads::Int64, cooperative::Bool, shmem::Int64, stream::CuStream)
    @ CUDA C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:73
  [4] launch
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:52 [inlined]
  [5] #972
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:189 [inlined]
  [6] macro expansion
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:149 [inlined]
  [7] macro expansion
    @ .\none:0 [inlined]
  [8] convert_arguments
    @ .\none:0 [inlined]
  [9] #cudacall#971
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:191 [inlined]
 [10] cudacall
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:187 [inlined]
 [11] macro expansion
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\src\compiler\execution.jl:279 [inlined]
 [12] macro expansion
    @ .\none:0 [inlined]
 [13] #_#1157
    @ .\none:0 [inlined]
 [14] (::KernelAbstractions.Kernel{CUDABackend, KernelAbstractions.NDIteration.StaticSize{(99708160,)}, KernelAbstractions.NDIteration.StaticSize{(256,)}, typeof(Main.InterClassCorrKernel.gpu_kernel_interclass_corr!)})(::CuArray{UInt8, 3, CUDA.DeviceMemory}, ::Vararg{Any}; ndrange::Nothing, workgroupsize::Nothing)
    @ CUDA.CUDAKernels C:\Users\Hp\.julia\packages\CUDA\2kjXI\src\CUDAKernels.jl:131
 [15] (::KernelAbstractions.Kernel{CUDABackend, KernelAbstractions.NDIteration.StaticSize{(99708160,)}, KernelAbstractions.NDIteration.StaticSize{(256,)}, typeof(Main.InterClassCorrKernel.gpu_kernel_interclass_corr!)})(::CuArray{UInt8, 3, CUDA.DeviceMemory}, ::Vararg{Any})
    @ CUDA.CUDAKernels C:\Users\Hp\.julia\packages\CUDA\2kjXI\src\CUDAKernels.jl:89
 [16] calculateInterclassCorr(flat_gold::CuArray{UInt8, 3, CUDA.DeviceMemory}, flat_segm::CuArray{UInt8, 3, CUDA.DeviceMemory}, number_to_look_for::UInt8)
    @ Main.InterClassCorrKernel D:\MedEval3D.jl\src\kernels\InterClassCorrKernel.jl:113
 [17] top-level scope
    @ D:\MedEval3D.jl\test\ICtest.jl:15
in expression starting at D:\MedEval3D.jl\test\ICtest.jl:15

caused by: CUDA error: invalid argument (code 1, ERROR_INVALID_VALUE)
Stacktrace:
  [1] throw_api_error(res::CUDA.cudaError_enum)
    @ CUDA C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\libcuda.jl:30
  [2] check
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\libcuda.jl:37 [inlined]
  [3] cuLaunchKernel
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\utils\call.jl:34 [inlined]
  [4] (::CUDA.var"#966#967"{Bool, Int64, CuStream, CuFunction, CuDim3, CuDim3})(kernelParams::Vector{Ptr{Nothing}})
    @ CUDA C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:66
  [5] macro expansion
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:33 [inlined]
  [6] macro expansion
    @ .\none:0 [inlined]
  [7] pack_arguments(::CUDA.var"#966#967"{Bool, Int64, CuStream, CuFunction, CuDim3, CuDim3}, ::CUDA.KernelState, ::CuDeviceArray{UInt8, 3, 1}, ::CuDeviceArray{UInt8, 3, 1}, ::CuDeviceVector{Float32, 1}, ::CuDeviceVector{Float32, 1}, ::CuDeviceVector{Float32, 1}, ::CuDeviceVector{Float32, 1}, ::UInt8, ::CuDeviceVector{Float32, 1})
    @ CUDA .\none:0
  [8] launch(::CuFunction, ::CUDA.KernelState, ::CuDeviceArray{UInt8, 3, 1}, ::CuDeviceArray{UInt8, 3, 1}, ::CuDeviceVector{Float32, 1}, ::CuDeviceVector{Float32, 1}, ::CuDeviceVector{Float32, 1}, ::CuDeviceVector{Float32, 1}, ::UInt8, ::CuDeviceVector{Float32, 1}; blocks::Int64, threads::Int64, cooperative::Bool, shmem::Int64, stream::CuStream)
    @ CUDA C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:59
  [9] launch
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:52 [inlined]
 [10] #972
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:189 [inlined]
 [11] macro expansion
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:149 [inlined]
 [12] macro expansion
    @ .\none:0 [inlined]
 [13] convert_arguments
    @ .\none:0 [inlined]
 [14] #cudacall#971
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:191 [inlined]
 [15] cudacall
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\lib\cudadrv\execution.jl:187 [inlined]
 [16] macro expansion
    @ C:\Users\Hp\.julia\packages\CUDA\2kjXI\src\compiler\execution.jl:279 [inlined]
 [17] macro expansion
    @ .\none:0 [inlined]
 [18] #_#1157
    @ .\none:0 [inlined]
 [19] (::KernelAbstractions.Kernel{CUDABackend, KernelAbstractions.NDIteration.StaticSize{(99708160,)}, KernelAbstractions.NDIteration.StaticSize{(256,)}, typeof(Main.InterClassCorrKernel.gpu_kernel_interclass_corr!)})(::CuArray{UInt8, 3, CUDA.DeviceMemory}, ::Vararg{Any}; ndrange::Nothing, workgroupsize::Nothing)
    @ CUDA.CUDAKernels C:\Users\Hp\.julia\packages\CUDA\2kjXI\src\CUDAKernels.jl:131
 [20] (::KernelAbstractions.Kernel{CUDABackend, KernelAbstractions.NDIteration.StaticSize{(99708160,)}, KernelAbstractions.NDIteration.StaticSize{(256,)}, typeof(Main.InterClassCorrKernel.gpu_kernel_interclass_corr!)})(::CuArray{UInt8, 3, CUDA.DeviceMemory}, ::Vararg{Any})
    @ CUDA.CUDAKernels C:\Users\Hp\.julia\packages\CUDA\2kjXI\src\CUDAKernels.jl:89
 [21] calculateInterclassCorr(flat_gold::CuArray{UInt8, 3, CUDA.DeviceMemory}, flat_segm::CuArray{UInt8, 3, CUDA.DeviceMemory}, number_to_look_for::UInt8)
    @ Main.InterClassCorrKernel D:\MedEval3D.jl\src\kernels\InterClassCorrKernel.jl:113
 [22] top-level scope
    @ D:\MedEval3D.jl\test\ICtest.jl:15
```