### PR TITLE
MedEval3D version 1.0 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MedEval3D"
 uuid = "07fe485e-7252-451c-a484-d20a4cdbbf79"
 authors = ["Jakub Mitura <53857487+jakubMitura14@users.noreply.github.com>"]
-version = "0.2.0"
+version = "1.0.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"


### PR DESCRIPTION
The Registry version is broken and does not install due to dependency issues.

This addresses that and fixes things further.

Upstream work is stuck due to this issue.